### PR TITLE
feat: add get file apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "jest",
     "example": "ts-node examples/index.ts",
     "example:publish": "ts-node examples/publish.ts",
-    "example:append": "ts-node examples/append.ts"
+    "example:append": "ts-node examples/append.ts",
+    "example:retrieve": "ts-node examples/retrieve.ts"
   },
   "keywords": [
     "ckb",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,9 @@ import {
   writeFile,
   getContentType,
   splitFileIntoChunks,
-  combineChunksToFile
+  combineChunksToFile,
+  getFileContentFromChain,
+  saveFileFromChain
 } from './utils/file';
 import {
   createCKBFSWitness,
@@ -323,6 +325,8 @@ export {
   getContentType,
   splitFileIntoChunks,
   combineChunksToFile,
+  getFileContentFromChain,
+  saveFileFromChain,
   
   // Witness utilities
   createCKBFSWitness,

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -106,4 +106,147 @@ export function splitFileIntoChunks(filePath: string, chunkSize: number): Uint8A
 export function combineChunksToFile(chunks: Uint8Array[], outputPath: string): void {
   const combinedBuffer = Buffer.concat(chunks.map(chunk => Buffer.from(chunk)));
   writeFile(outputPath, combinedBuffer);
+}
+
+/**
+ * Utility function to safely decode buffer to string
+ * @param buffer The buffer to decode
+ * @returns Decoded string or placeholder on error
+ */
+function safelyDecode(buffer: any): string {
+  if (!buffer) return '[Unknown]';
+  try {
+    if (buffer instanceof Uint8Array) {
+      return new TextDecoder().decode(buffer);
+    } else if (typeof buffer === 'string') {
+      return buffer;
+    } else {
+      return `[Buffer: ${buffer.toString()}]`;
+    }
+  } catch (e) {
+    return '[Decode Error]';
+  }
+}
+
+/**
+ * Retrieves complete file content from the blockchain by following backlinks
+ * @param client The CKB client to use for blockchain queries
+ * @param outPoint The output point of the latest CKBFS cell
+ * @param ckbfsData The data from the latest CKBFS cell
+ * @returns Promise resolving to the complete file content
+ */
+export async function getFileContentFromChain(
+  client: any,
+  outPoint: { txHash: string; index: number },
+  ckbfsData: any
+): Promise<Uint8Array> {
+  console.log(`Retrieving file: ${safelyDecode(ckbfsData.filename)}`);
+  console.log(`Content type: ${safelyDecode(ckbfsData.contentType)}`);
+  
+  // Prepare to collect all content pieces
+  const contentPieces: Uint8Array[] = [];
+  let currentData = ckbfsData;
+  let currentOutPoint = outPoint;
+  
+  // Process the current transaction first
+  const tx = await client.getTransaction(currentOutPoint.txHash);
+  if (!tx || !tx.transaction) {
+    throw new Error(`Transaction ${currentOutPoint.txHash} not found`);
+  }
+  
+  // Get content from witnesses
+  const indexes = currentData.indexes || (currentData.index !== undefined ? [currentData.index] : []);
+  if (indexes.length > 0) {
+    // Get content from each witness index
+    for (const idx of indexes) {
+      if (idx >= tx.transaction.witnesses.length) {
+        console.warn(`Witness index ${idx} out of range`);
+        continue;
+      }
+      
+      const witnessHex = tx.transaction.witnesses[idx];
+      const witness = Buffer.from(witnessHex.slice(2), 'hex'); // Remove 0x prefix
+      
+      // Extract content (skip CKBFS header + version byte)
+      if (witness.length >= 6 && witness.slice(0, 5).toString() === 'CKBFS') {
+        const content = witness.slice(6);
+        contentPieces.unshift(content); // Add to beginning of array (we're going backwards)
+      } else {
+        console.warn(`Witness at index ${idx} is not a valid CKBFS witness`);
+      }
+    }
+  }
+  
+  // Follow backlinks recursively
+  if (currentData.backLinks && currentData.backLinks.length > 0) {
+    // Process each backlink, from most recent to oldest
+    for (let i = currentData.backLinks.length - 1; i >= 0; i--) {
+      const backlink = currentData.backLinks[i];
+      
+      // Get the transaction for this backlink
+      const backTx = await client.getTransaction(backlink.txHash);
+      if (!backTx || !backTx.transaction) {
+        console.warn(`Backlink transaction ${backlink.txHash} not found`);
+        continue;
+      }
+      
+      // Get content from backlink witnesses
+      const backIndexes = backlink.indexes || (backlink.index !== undefined ? [backlink.index] : []);
+      if (backIndexes.length > 0) {
+        // Get content from each witness index
+        for (const idx of backIndexes) {
+          if (idx >= backTx.transaction.witnesses.length) {
+            console.warn(`Backlink witness index ${idx} out of range`);
+            continue;
+          }
+          
+          const witnessHex = backTx.transaction.witnesses[idx];
+          const witness = Buffer.from(witnessHex.slice(2), 'hex'); // Remove 0x prefix
+          
+          // Extract content (skip CKBFS header + version byte)
+          if (witness.length >= 6 && witness.slice(0, 5).toString() === 'CKBFS') {
+            const content = witness.slice(6);
+            contentPieces.unshift(content); // Add to beginning of array (we're going backwards)
+          } else {
+            console.warn(`Backlink witness at index ${idx} is not a valid CKBFS witness`);
+          }
+        }
+      }
+    }
+  }
+  
+  // Combine all content pieces
+  return Buffer.concat(contentPieces);
+}
+
+/**
+ * Saves file content retrieved from blockchain to disk
+ * @param content The file content to save
+ * @param ckbfsData The CKBFS cell data containing file metadata
+ * @param outputPath Optional path to save the file (defaults to filename in current directory)
+ * @returns The path where the file was saved
+ */
+export function saveFileFromChain(
+  content: Uint8Array,
+  ckbfsData: any,
+  outputPath?: string
+): string {
+  // Get filename from CKBFS data
+  const filename = safelyDecode(ckbfsData.filename);
+  
+  // Determine output path
+  const filePath = outputPath || filename;
+  
+  // Ensure directory exists
+  const directory = path.dirname(filePath);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  
+  // Write file
+  fs.writeFileSync(filePath, content);
+  console.log(`File saved to: ${filePath}`);
+  console.log(`Size: ${content.length} bytes`);
+  
+  return filePath;
 } 


### PR DESCRIPTION
This pull request introduces new functionality for retrieving and saving file content from the blockchain, along with some minor updates to the `package.json` and `src/index.ts` files. The main changes include the addition of utility functions and the necessary updates to import and export statements.

### New functionality:

* Added `getFileContentFromChain` function to retrieve complete file content from the blockchain by following backlinks.
* Added `saveFileFromChain` function to save file content retrieved from the blockchain to disk.
* Introduced `safelyDecode` utility function to safely decode buffer to string, handling errors gracefully.

### Updates to import/export statements:

* Updated `src/index.ts` to include new imports for `getFileContentFromChain` and `saveFileFromChain`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L25-R27) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R328-R329)

### Minor changes:

* Added a new script `example:retrieve` in `package.json` to run the new functionality examples.