### PR TITLE
feat: add preparePublishTransaction,  createAppendTransactionDry

### DIFF
--- a/examples/publish.ts
+++ b/examples/publish.ts
@@ -6,11 +6,11 @@ const privateKey = process.env.CKB_PRIVATE_KEY || 'your-private-key-here';
 // Initialize the SDK with network and version options
 const ckbfs = new CKBFS(
   privateKey,
-  NetworkType.Mainnet, // Use testnet
+  NetworkType.Testnet, // Use testnet
   {
     version: ProtocolVersion.V2, // Use the latest version (V2)
     chunkSize: 30 * 1024, // 30KB chunks
-    useTypeID: false // Use code hash instead of type ID
+    useTypeID: false, // Use code hash instead of type ID
   }
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   createCKBFSCell,
   createPublishTransaction as utilCreatePublishTransaction,
   createAppendTransaction as utilCreateAppendTransaction,
+  createAppendTransactionDry,
   publishCKBFS as utilPublishCKBFS,
   appendCKBFS as utilAppendCKBFS,
   CKBFSCellOptions,
@@ -122,6 +123,7 @@ export interface CKBFSOptions {
   version?: ProtocolVersionType;
   useTypeID?: boolean;
   network?: NetworkType;
+  rpcUrl?: string;
 }
 
 /**
@@ -133,6 +135,7 @@ export class CKBFS {
   private network: NetworkType;
   private version: ProtocolVersionType;
   private useTypeID: boolean;
+  private rpcUrl: string;
 
   /**
    * Creates a new CKBFS SDK instance
@@ -159,13 +162,18 @@ export class CKBFS {
 
       const client =
         network === "mainnet"
-          ? new ClientPublicMainnet()
-          : new ClientPublicTestnet();
+          ? new ClientPublicMainnet({
+            url: opts.rpcUrl,
+          })
+          : new ClientPublicTestnet({
+            url: opts.rpcUrl,
+          });
       this.signer = new SignerCkbPrivateKey(client, privateKey);
       this.network = network;
       this.chunkSize = opts.chunkSize || 30 * 1024;
       this.version = opts.version || DEFAULT_VERSION;
       this.useTypeID = opts.useTypeID || false;
+      this.rpcUrl = opts.rpcUrl || client.url;
     } else {
       // Initialize with signer
       this.signer = signerOrPrivateKey;
@@ -175,6 +183,7 @@ export class CKBFS {
       this.chunkSize = opts.chunkSize || 30 * 1024;
       this.version = opts.version || DEFAULT_VERSION;
       this.useTypeID = opts.useTypeID || false;
+      this.rpcUrl = opts.rpcUrl || this.signer.client.url;
     }
   }
 
@@ -522,7 +531,7 @@ export {
   utilCreateAppendTransaction as createAppendTransaction,
   utilPublishCKBFS as publishCKBFS,
   utilAppendCKBFS as appendCKBFS,
-
+  createAppendTransactionDry,
   // File utilities
   readFile,
   readFileAsText,

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -34,6 +34,7 @@ export interface CKBFSCellOptions {
 export interface PublishOptions extends CKBFSCellOptions {
   contentChunks: Uint8Array[];
   feeRate?: number;
+  from?: Transaction;
 }
 
 /**
@@ -100,29 +101,27 @@ export function createCKBFSCell(options: CKBFSCellOptions) {
 }
 
 /**
- * Creates a transaction for publishing a file to CKBFS
- * @param signer The signer to use for the transaction
+ * Prepares a transaction for publishing a file to CKBFS without fee and change handling
+ * You will need to manually set the typeID if you did not provide inputs, or just check is return value emptyTypeID is true
  * @param options Options for publishing the file
- * @returns Promise resolving to the created transaction
+ * @returns Promise resolving to the prepared transaction and the output index of CKBFS Cell
  */
-export async function createPublishTransaction(
-  signer: Signer,
+export async function preparePublishTransaction(
   options: PublishOptions,
-): Promise<Transaction> {
+): Promise<{tx: Transaction, outputIndex: number, emptyTypeID: boolean}> { // if emptyTypeID is true, you shall manually set the typeID after
   const {
+    from,
     contentChunks,
     contentType,
     filename,
     lock,
     capacity,
-    feeRate,
     network = DEFAULT_NETWORK,
     version = DEFAULT_VERSION,
     useTypeID = false,
   } = options;
 
   // Calculate checksum for the combined content
-  const textEncoder = new TextEncoder();
   const combinedContent = Buffer.concat(contentChunks);
   const checksum = await calculateChecksum(combinedContent);
 
@@ -132,9 +131,8 @@ export async function createPublishTransaction(
   const ckbfsWitnesses = createChunkedCKBFSWitnesses(contentChunks);
 
   // Calculate the actual witness indices where our content is placed
-  // Index 0 is reserved for the secp256k1 witness for signing
-  // So our CKBFS data starts at index 1
-  const contentStartIndex = 1;
+
+  const contentStartIndex = from?.witnesses.length || 1;
   const witnessIndices = Array.from(
     { length: contentChunks.length },
     (_, i) => contentStartIndex + i,
@@ -187,24 +185,71 @@ export async function createPublishTransaction(
         8,
     ) * 100000000n;
   // Create pre transaction without cell deps initially
-  const preTx = Transaction.from({
-    outputs: [
-      createCKBFSCell({
-        contentType,
-        filename,
-        lock,
-        network,
-        version,
-        useTypeID,
-        capacity: ckbfsCellSize || capacity,
-      }),
-    ],
-    witnesses: [
-      [], // Empty secp witness for signing
-      ...ckbfsWitnesses.map((w) => `0x${Buffer.from(w).toString("hex")}`),
-    ],
-    outputsData: [outputData],
-  });
+  let preTx: Transaction;
+  if(from) {
+    // If from is not empty, inject/merge the fields
+    preTx = Transaction.from({
+      ...from,
+      outputs: from.outputs.length === 0 
+        ? [
+            createCKBFSCell({
+              contentType,
+              filename,
+              lock,
+              network,
+              version,
+              useTypeID,
+              capacity: ckbfsCellSize || capacity,
+            }),
+          ]
+        : [
+            ...from.outputs,
+            createCKBFSCell({
+              contentType,
+              filename,
+              lock,
+              network,
+              version,
+              useTypeID,
+              capacity: ckbfsCellSize || capacity,
+            }),
+          ],
+      witnesses: from.witnesses.length === 0 
+        ? [
+            [], // Empty secp witness for signing if not provided
+            ...ckbfsWitnesses.map((w) => `0x${Buffer.from(w).toString("hex")}`),
+          ]
+        : [
+            ...from.witnesses,
+            ...ckbfsWitnesses.map((w) => `0x${Buffer.from(w).toString("hex")}`),
+          ],
+      outputsData: from.outputsData.length === 0 
+        ? [outputData]
+        : [
+            ...from.outputsData,
+            outputData,
+          ],
+    });
+  } else {
+      preTx = Transaction.from({
+        outputs: [
+          createCKBFSCell({
+            contentType,
+            filename,
+            lock,
+            network,
+            version,
+            useTypeID,
+            capacity: ckbfsCellSize || capacity,
+          }),
+        ],
+        witnesses: [
+          [], // Empty secp witness for signing
+          ...ckbfsWitnesses.map((w) => `0x${Buffer.from(w).toString("hex")}`),
+        ],
+        outputsData: [outputData],
+      });
+  }
 
   // Add the CKBFS dep group cell dependency
   preTx.addCellDeps({
@@ -215,17 +260,9 @@ export async function createPublishTransaction(
     depType: "depGroup",
   });
 
-  // Get the recommended address to ensure lock script cell deps are included
-  const address = await signer.getRecommendedAddressObj();
-
-  // Complete inputs by capacity
-  await preTx.completeInputsByCapacity(signer);
-
-  // Complete fee change to lock
-  await preTx.completeFeeChangeToLock(signer, lock, feeRate || 2000);
-
   // Create type ID args
-  const args = ccc.hashTypeId(preTx.inputs[0], 0x0);
+  const outputIndex = from ? from.outputs.length : 0;
+  const args = preTx.inputs.length > 0 ? ccc.hashTypeId(preTx.inputs[0], outputIndex) : "0x0000000000000000000000000000000000000000000000000000000000000000";
 
   // Create CKBFS type script with type ID
   const ckbfsTypeScript = new Script(
@@ -237,23 +274,99 @@ export async function createPublishTransaction(
   // Create final transaction with same cell deps as preTx
   const tx = Transaction.from({
     cellDeps: preTx.cellDeps,
-    witnesses: [
-      [], // Reset first witness for signing
-      ...preTx.witnesses.slice(1),
-    ],
+    witnesses: preTx.witnesses,
     outputsData: preTx.outputsData,
     inputs: preTx.inputs,
-    outputs: [
-      {
-        lock,
-        type: ckbfsTypeScript,
-        capacity: preTx.outputs[0].capacity,
-      },
-      ...preTx.outputs.slice(1), // Include rest of outputs (e.g., change)
-    ],
+    outputs: outputIndex === 0 
+      ? [
+          {
+            lock,
+            type: ckbfsTypeScript,
+            capacity: preTx.outputs[outputIndex].capacity,
+          },
+        ]
+      : [
+          ...preTx.outputs.slice(0, outputIndex), // Include rest of outputs (e.g., change)
+          {
+            lock,
+            type: ckbfsTypeScript,
+            capacity: preTx.outputs[outputIndex].capacity,
+          },
+        ],
   });
 
-  return tx;
+  return {tx, outputIndex, emptyTypeID: args === "0x0000000000000000000000000000000000000000000000000000000000000000"};
+}
+
+/**
+ * Creates a transaction for publishing a file to CKBFS
+ * @param signer The signer to use for the transaction
+ * @param options Options for publishing the file
+ * @returns Promise resolving to the created transaction
+ */
+export async function createPublishTransaction(
+  signer: Signer,
+  options: PublishOptions,
+): Promise<Transaction> {
+  const {
+    feeRate,
+    lock,
+  } = options;
+
+  // Use preparePublishTransaction to create the base transaction
+  const { tx: preTx, outputIndex, emptyTypeID } = await preparePublishTransaction(options);
+
+  // Complete inputs by capacity
+  await preTx.completeInputsByCapacity(signer);
+
+  // Complete fee change to lock
+  await preTx.completeFeeChangeToLock(signer, lock, feeRate || 2000);
+
+  // If emptyTypeID is true, we need to create the proper type ID args
+  if (emptyTypeID) {
+    // Get CKBFS script config
+    const config = getCKBFSScriptConfig(options.network || DEFAULT_NETWORK, options.version || DEFAULT_VERSION, options.useTypeID || false);
+    
+    // Create type ID args
+    const args = ccc.hashTypeId(preTx.inputs[0], outputIndex);
+
+    // Create CKBFS type script with type ID
+    const ckbfsTypeScript = new Script(
+      ensureHexPrefix(config.codeHash),
+      config.hashType as any,
+      args,
+    );
+
+    // Create final transaction with updated type script
+    const tx = Transaction.from({
+      cellDeps: preTx.cellDeps,
+      witnesses: preTx.witnesses,
+      outputsData: preTx.outputsData,
+      inputs: preTx.inputs,
+      outputs: preTx.outputs.map((output, index) => 
+        index === outputIndex 
+          ? {
+              lock,
+              type: ckbfsTypeScript,
+              capacity: output.capacity,
+            }
+          : output
+      ),
+    });
+
+    return tx;
+  } else {
+    // If typeID was already set properly, just reset the first witness for signing
+    const tx = Transaction.from({
+      cellDeps: preTx.cellDeps,
+      witnesses: preTx.witnesses,
+      outputsData: preTx.outputsData,
+      inputs: preTx.inputs,
+      outputs: preTx.outputs,
+    });
+
+    return tx;
+  }
 }
 
 /**
@@ -447,6 +560,200 @@ export async function createAppendTransaction(
 
   // Complete fee
   await tx.completeFeeChangeToLock(signer, address.script, feeRate || 2000);
+
+  return tx;
+}
+
+/**
+ * Creates a transaction for appending content to a CKBFS file
+ * @param signer The signer to use for the transaction
+ * @param options Options for appending content
+ * @returns Promise resolving to the created transaction
+ */
+export async function createAppendTransactionDry(
+  signer: Signer,
+  options: AppendOptions,
+): Promise<Transaction> {
+  const {
+    ckbfsCell,
+    contentChunks,
+    network = DEFAULT_NETWORK,
+    version = DEFAULT_VERSION,
+  } = options;
+  const { outPoint, data, type, lock, capacity } = ckbfsCell;
+
+  // Get CKBFS script config early to use version info
+  const config = getCKBFSScriptConfig(network, version);
+
+  // Create CKBFS witnesses - each chunk already includes the CKBFS header
+  // Pass 0 as version byte - this is the protocol version byte in the witness header
+  // not to be confused with the Protocol Version (V1 vs V2)
+  const ckbfsWitnesses = createChunkedCKBFSWitnesses(contentChunks);
+
+  // Combine the new content chunks for checksum calculation
+  const combinedContent = Buffer.concat(contentChunks);
+
+  // Update the existing checksum with the new content - this matches Adler32's
+  // cumulative nature as required by Rule 11 in the RFC
+  const contentChecksum = await updateChecksum(data.checksum, combinedContent);
+  console.log(
+    `Updated checksum from ${data.checksum} to ${contentChecksum} for appended content`,
+  );
+
+  // Get the recommended address to ensure lock script cell deps are included
+  const address = await signer.getRecommendedAddressObj();
+
+  // Calculate the actual witness indices where our content is placed
+  // CKBFS data starts at index 1 if signer's lock script is the same as ckbfs's lock script
+  // else CKBFS data starts at index 0
+  const contentStartIndex = address.script.hash() === lock.hash() ? 1 : 0;
+  const witnessIndices = Array.from(
+    { length: contentChunks.length },
+    (_, i) => contentStartIndex + i,
+  );
+
+  // Create backlink for the current state based on version
+  let newBackLink: any;
+
+  if (version === ProtocolVersion.V1) {
+    // V1 format: Use index field (single number)
+    newBackLink = {
+      // In V1, field order is index, checksum, txHash
+      // and index is a single number value, not an array
+      index:
+        data.index ||
+        (data.indexes && data.indexes.length > 0 ? data.indexes[0] : 0),
+      checksum: data.checksum,
+      txHash: outPoint.txHash,
+    };
+  } else {
+    // V2 format: Use indexes field (array of numbers)
+    newBackLink = {
+      // In V2, field order is indexes, checksum, txHash
+      // and indexes is an array of numbers
+      indexes: data.indexes || (data.index ? [data.index] : []),
+      checksum: data.checksum,
+      txHash: outPoint.txHash,
+    };
+  }
+
+  // Update backlinks - add the new one to the existing backlinks array
+  const backLinks = [...(data.backLinks || []), newBackLink];
+
+  // Define output data based on version
+  let outputData: Uint8Array;
+
+  if (version === ProtocolVersion.V1) {
+    // In V1, index is a single number, not an array
+    // The first witness index is used (V1 can only reference one witness)
+    outputData = CKBFSData.pack(
+      {
+        index: witnessIndices[0], // Use only the first index as a number
+        checksum: contentChecksum,
+        contentType: data.contentType,
+        filename: data.filename,
+        backLinks,
+      },
+      ProtocolVersion.V1,
+    ); // Explicitly use V1 for packing
+  } else {
+    // In V2, indexes is an array of witness indices
+    outputData = CKBFSData.pack(
+      {
+        indexes: witnessIndices,
+        checksum: contentChecksum,
+        contentType: data.contentType,
+        filename: data.filename,
+        backLinks,
+      },
+      ProtocolVersion.V2,
+    ); // Explicitly use V2 for packing
+  }
+
+  // Pack the original data to get its size - use the appropriate version
+  const originalData = CKBFSData.pack(data, version);
+  const originalDataSize = originalData.length;
+
+  // Get sizes and calculate capacity requirements
+  const newDataSize = outputData.length;
+
+  // Calculate the required capacity for the output cell
+  // This accounts for:
+  // 1. The output data size
+  // 2. The type script's occupied size
+  // 3. The lock script's occupied size
+  // 4. A constant of 8 bytes (for header overhead)
+  const ckbfsCellSize =
+    BigInt(outputData.length + type.occupiedSize + lock.occupiedSize + 8) *
+    100000000n;
+
+  console.log(
+    `Original capacity: ${capacity}, Calculated size: ${ckbfsCellSize}, Data size: ${outputData.length}`,
+  );
+
+  // Use the maximum value between calculated size and original capacity
+  // to ensure we have enough capacity but don't decrease capacity unnecessarily
+  const outputCapacity = ckbfsCellSize > capacity ? ckbfsCellSize : capacity;
+
+  // Create initial transaction with the CKBFS cell input
+  const tx = Transaction.from({
+    inputs: [
+      {
+        previousOutput: {
+          txHash: outPoint.txHash,
+          index: outPoint.index,
+        },
+        since: "0x0",
+      },
+    ],
+    outputs: [
+      {
+        lock,
+        type,
+        capacity: outputCapacity,
+      },
+    ],
+    outputsData: [outputData],
+  });
+
+  // Add the CKBFS dep group cell dependency
+  tx.addCellDeps({
+    outPoint: {
+      txHash: ensureHexPrefix(config.depTxHash),
+      index: config.depIndex || 0,
+    },
+    depType: "depGroup",
+  });
+
+  const inputsBefore = tx.inputs.length;
+  // // If we need more capacity than the original cell had, add additional inputs
+  // if (outputCapacity > capacity) {
+  //   console.log(
+  //     `Need additional capacity: ${outputCapacity - capacity} shannons`,
+  //   );
+  //   // Add more inputs to cover the increased capacity
+  //   await tx.completeInputsByCapacity(signer);
+  // }
+
+  const witnesses: any = [];
+  // add empty witness for signer if ckbfs's lock is the same as signer's lock
+  if (address.script.hash() === lock.hash()) {
+    witnesses.push("0x");
+  }
+  // add ckbfs witnesses
+  witnesses.push(
+    ...ckbfsWitnesses.map((w) => `0x${Buffer.from(w).toString("hex")}`),
+  );
+
+  // Add empty witnesses for signer's input
+  // This is to ensure that the transaction is valid and can be signed
+  for (let i = inputsBefore; i < tx.inputs.length; i++) {
+    witnesses.push("0x");
+  }
+  tx.witnesses = witnesses;
+
+  // Complete fee
+  //await tx.completeFeeChangeToLock(signer, address.script, feeRate || 2000);
 
   return tx;
 }


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the CKBFS SDK, primarily focusing on transaction creation flexibility, improved configuration options, and new utility functions for advanced usage. The most significant changes are the addition of "dry" transaction preparation methods, support for custom RPC URLs, and more granular control over transaction construction for publishing and appending files.

### Transaction Creation Improvements

* Added `preparePublishTransaction` and refactored `createPublishTransaction` in `src/utils/transaction.ts` to allow for transaction preparation without fee and change handling, enabling advanced users to manually set type IDs and customize inputs/outputs. This includes support for merging with an existing transaction (`from`), returning additional metadata, and improved witness handling. [[1]](diffhunk://#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17L103-L125) [[2]](diffhunk://#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17L190-R234) [[3]](diffhunk://#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17L218-R331) [[4]](diffhunk://#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17L237-R370)
* Introduced `createAppendTransactionDry` in `src/utils/transaction.ts` for preparing append transactions without fee/change completion, giving developers more control over transaction construction and capacity management. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R19) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L525-R534) [[3]](diffhunk://#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17R567-R760)

### SDK Configuration Enhancements

* Added support for specifying a custom `rpcUrl` in `CKBFSOptions` and propagated this option throughout the SDK, allowing users to target specific CKB nodes for transactions. This affects both the SDK initialization and internal client instantiation. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R126) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R138) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L162-R176) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R186)

### Utility and API Surface Changes

* Updated the SDK exports in `src/index.ts` to include new utility functions (`createAppendTransactionDry`) and improved transaction creation methods, making them accessible to users of the library. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R19) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L525-R534)
* Extended the `PublishOptions` interface to accept an optional `from` transaction, enabling advanced composition scenarios for publishing files.

### Minor Fixes

* Fixed incorrect network type usage in the `examples/publish.ts` example, ensuring it now correctly uses `NetworkType.Testnet` for testnet deployments.